### PR TITLE
Feature/acd 890 refactoring labeling

### DIFF
--- a/accutuning_helpers/text/embedder_bert.py
+++ b/accutuning_helpers/text/embedder_bert.py
@@ -1,33 +1,34 @@
-from typing import Iterable, List
 import logging
+from typing import Iterable, List
+
 import numpy as np
 import pandas as pd
 from flair.data import Tokenizer
-from flair.embeddings import DocumentEmbeddings
-from sentence_transformers import models, SentenceTransformer
+from sentence_transformers import SentenceTransformer
 
 from accutuning_helpers.text.embedder import TokenEmbedderBase
 
 logger = logging.getLogger(__name__)
 
 
-class BERTVectorizer(TokenEmbedderBase, DocumentEmbeddings):
+class BERTVectorizer(TokenEmbedderBase):
 
 	def __init__(
 			self,
 			feature_name,
-			bert_model_name='bert-base-multilingual-cased',
+			bert_model_name='sentence-transformers/distiluse-base-multilingual-cased-v1',
 	):
 		super(BERTVectorizer, self).__init__(feature_name)
-		logger.critical("BERT Vectorizer is deprecated. Use TFIDF embedder instead.")
 
-		word_embedding_model = models.Transformer(bert_model_name)
-		pooling_model = models.Pooling(
-			word_embedding_model.get_word_embedding_dimension(),
-			pooling_mode_mean_tokens=True,
-			pooling_mode_cls_token=False,
-			pooling_mode_max_tokens=False)
-		self.model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
+		# 학습하지 않은 BERT 대신 sentence transformers가 자체적으로 multilingual로 학습한 vector로 수정
+		# word_embedding_model = models.Transformer(bert_model_name)
+		# pooling_model = models.Pooling(
+		# 	word_embedding_model.get_word_embedding_dimension(),
+		# 	pooling_mode_mean_tokens=True,
+		# 	pooling_mode_cls_token=False,
+		# 	pooling_mode_max_tokens=False)
+		# self.model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
+		self.model = SentenceTransformer(bert_model_name)
 		self._tokenizer = _Tokenizer(delegator=self.model)
 
 	def fit(self, X, y=0, **fit_params):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         "flair==0.11.3",
         "sentencepiece>=0.1.95",
         "datasets>=2.3.2", # Huggingface datasets
-        "sentence-transformers==0.3.9",
-        "protobuf==3.20.0",
+        "sentence-transformers>=2.2",
+        # "protobuf==3.20.0",
     ]
 )

--- a/tests/text/test_embedder_bert.py
+++ b/tests/text/test_embedder_bert.py
@@ -31,7 +31,7 @@ class TestBERTVectorizer(TestCase):
 		X = self.df
 		self.embedder.fit(X)
 		print(f'\nvocab lenghth:{self.embedder.embedding_length}')
-		assert self.embedder.embedding_length == 768
+		assert self.embedder.embedding_length == 512
 
 	def test_transform(self):
 		X = self.df
@@ -39,13 +39,13 @@ class TestBERTVectorizer(TestCase):
 		# print(f'vector:{vec}')
 		print(f'vector.shape:{vec.shape}')
 		# assert vec.shape[1] == 9994
-		assert vec.shape[1] == 768
+		assert vec.shape[1] == 512 + 2
 
 	def test_fit_transform(self):
 		X = self.df
 		vec = self.embedder.fit_transform(X)
 		print(f'\nvocab lenghth:{self.embedder.embedding_length}')
 		# assert self.embedder.embedding_length == 9994
-		assert self.embedder.embedding_length == 74
+		assert self.embedder.embedding_length == 512
 		print(f'vector:{vec}')
 		print(f'vector.shape:{vec.shape}')


### PR DESCRIPTION
setup.py sentence-transformer 버전 0.3.9 문제를 해결
- BertVectorizer 2.2.1 compatible하도록 수정 (+ 단위 테스트 확인 완료)
- sentence-transformer version : 0.3.9 -> 2.2.1 로 변경 
   - flair 와의 transformers library version 충돌 해결
- protobuf 3.20.0 주석 처리
  - sentence-transformers 2.x는 protocol buffer 사용하지 않음