### PR TITLE
sentence transformers 2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ setup(
         "cleanlab>=1.0",
         "flair==0.11.3",
         "sentencepiece>=0.1.95",
-        # "datasets>2.3.2", # Huggingface datasets 
-        "sentence-transformers==0.3.9",
-        "protobuf==3.20.0",
+        "datasets>=2.3.2", # Huggingface datasets
+        "sentence-transformers>=2.2",
+        # "protobuf==3.20.0",
     ]
 )


### PR DESCRIPTION
- setup.py sentence-transformer 버전 0.3.9 문제를 해결
- sentence-transformer version : 0.3.9 -> 2.2.1 로 변경
   - (flair 와의 transformers library version 충돌 해결)
- protobuf 3.20.0 주석 처리
   - (sentence-transformers 2.x는 protocol buffer 사용하지 않음)